### PR TITLE
署名付きurl対応

### DIFF
--- a/api/server/server.js
+++ b/api/server/server.js
@@ -9,6 +9,7 @@ var fork = require('child_process').fork;
 const appSettings = require("../app-settings");
 const {app} = require('electron');
 const log = require('electron-log');
+const cwd = path.join(__dirname, '..')
 
 const CHILD_SCRIPT_FILENAME = 'startServer.js';
 
@@ -67,7 +68,13 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
   log.info('fork前')
-  self.childProcess = fork(cp_path, []);
+  log.info(`cwd = ${cwd}`)
+  if (fs.existsSync(path.join(cwd, 'app.asar'))) {
+    log.info('app.asarあり')
+  }
+  self.childProcess = fork(cp_path, [], {
+    cwd: cwd
+  });
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -58,20 +58,12 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
     }
   }
 
-  const fs   = require('fs')
-  const path = require('path')
-  const cwd  = path.join(__dirname, '..')
-  let cp_path
-
-  if (fs.existsSync(path.join(cwd, 'app.asar'))) {
-    cp_path = 'app.asar/startServer.js';
-  }
-  log.info(`cp_path = ${cp_path}`)
+  const cp_path = 'app.asar/startServer.js';
 
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   let script = '/Users/ogawamasahiro/Desktop/Project/downstream_electron/startServer.js';
-  log.info('Script for server:', script);
+  log.info('Script for server:', cp_path);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
   log.info('fork前')

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -61,8 +61,8 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
-  // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  let script = '/Applications/startServer.js';
+  let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
+  // let script = '/Applications/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -71,10 +71,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   if (fs.existsSync(path.join(cwd, CHILD_SCRIPT_FILENAME))) {
     log.info('startServer.jsあり')
   }
-  // self.childProcess = fork(cp_path, [], {
-  //   cwd: cwd
-  // });
-  self.childProcess = fork("/Applications/mgsplayer.app/Contents/Resources/app/node_modules/downstream-electron/startServer.js", []);
+  self.childProcess = fork("/Applications/mgsplayer.app/Contents/Resources/app.asar/node_modules/downstream-electron/startServer.js", []);
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -46,10 +46,13 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
       serverPath = app.getAppPath();
       console.log(`3 serverPath = ${serverPath}`);
       console.log(`__dirname = ${__dirname}`);
-      console.log(`process.cwd() = ${process.cwd()}`);
+      console.log(`root path = ${path.join(process.cwd(), CHILD_SCRIPT_FILENAME)}`);
       if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
-        serverPath = __dirname;
-        console.log(`4 serverPath = ${serverPath}`);
+        serverPath = process.cwd()
+        if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
+          serverPath = __dirname;
+          console.log(`4 serverPath = ${serverPath}`);
+        }
       }
     }
   }

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -87,6 +87,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   })
   // handles message from child process
   self.childProcess.on('message', function (data) {
+    log.info('message = ', data);
     if (data.cmd === 'log') {
       // http server wants to log some data
       console.log(data.log);

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -74,7 +74,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   // self.childProcess = fork(cp_path, [], {
   //   cwd: cwd
   // });
-  self.childProcess = fork("./startServer", []);
+  self.childProcess = fork("/Applications/mgsplayer.app/Contents/Resources/app/node_modules/downstream-electron/startServer.js", []);
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -61,8 +61,8 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
-  let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  // let script = '/Users/ogawamasahiro/Desktop/Project/downstream_electron/startServer.js';
+  // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
+  let script = '/Users/ogawamasahiro/Desktop/Project/mgsplayer_pc_vue_electron/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
@@ -74,9 +74,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   // self.childProcess = fork(cp_path, [], {
   //   cwd: cwd
   // });
-  self.childProcess = fork(script, [], {
-    cwd: '/Users/ogawamasahiro/Desktop/'
-  });
+  self.childProcess = fork(script, []);
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -45,6 +45,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
     if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
       serverPath = app.getAppPath();
       console.log(`3 serverPath = ${serverPath}`);
+      console.log(`__dirname = ${__dirname}`);
       if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
         serverPath = __dirname;
         console.log(`4 serverPath = ${serverPath}`);

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 var fork = require('child_process').fork;
 const appSettings = require("../app-settings");
 const {app} = require('electron');
+const log = require('electron-log');
 
 const CHILD_SCRIPT_FILENAME = 'startServer.js';
 
@@ -38,15 +39,15 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   // NOTE: this is so ugly FIXME
   let serverPath = path.join(app.getAppPath(), 'node_modules/downstream-electron');
-  console.log(`1 serverPath = ${serverPath}`);
+  log.info(`1 serverPath = ${serverPath}`);
   if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
     serverPath = path.join(app.getAppPath(), 'node_modules/downstream-electron/api/server');
-    console.log(`2 serverPath = ${serverPath}`);
+    log.info(`2 serverPath = ${serverPath}`);
     if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
       serverPath = app.getAppPath();
-      console.log(`3 serverPath = ${serverPath}`);
-      console.log(`__dirname = ${__dirname}`);
-      console.log(`root path = ${path.join(process.cwd(), CHILD_SCRIPT_FILENAME)}`);
+      log.info(`app.getAppPath() = ${serverPath}`);
+      log.info(`__dirname = ${__dirname}`);
+      log.info(`process.cwd() = ${process.cwd()}`);
       if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
         serverPath = process.cwd()
         if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -62,7 +62,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  let script = '/Users/ogawamasahiro/Desktop/Project/mgsplayer_pc_vue_electron/startServer.js';
+  let script = '/Applications/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -67,7 +67,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
   log.info('fork前')
-  self.childProcess = fork(script, []);
+  self.childProcess = fork(cp_path, []);
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -62,7 +62,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  let script = '/Applications/mgsplayer.app/Contents/Resources/app.asar/startServer.js';
+  let script = '/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -62,7 +62,8 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  let script = '/Applications/mgsplayer.app/Contents/Resources/app.asar/startServer.js';
+  // let script = '/Applications/mgsplayer.app/Contents/Resources/app.asar/startServer.js';
+  let script = path.join(app.getAppPath(), 'Contents/Resources/app/node_modules/downstream-electron', CHILD_SCRIPT_FILENAME)
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -62,7 +62,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  let script = '/Users/ogawamasahiro/Desktop/startServer.js';
+  let script = '/Applications/mgsplayer.app/Contents/Resources/app.asar/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
@@ -74,7 +74,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   // self.childProcess = fork(cp_path, [], {
   //   cwd: cwd
   // });
-  self.childProcess = fork(script, []);
+  self.childProcess = fork("./startServer", []);
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -63,7 +63,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
   // let script = '/Applications/mgsplayer.app/Contents/Resources/app.asar/startServer.js';
-  let script = path.join(app.getAppPath(), 'Contents/Resources/app/node_modules/downstream-electron', CHILD_SCRIPT_FILENAME)
+  let script = path.join(app.getAppPath(), 'node_modules/downstream-electron', CHILD_SCRIPT_FILENAME)
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
@@ -72,7 +72,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   if (fs.existsSync(path.join(cwd, CHILD_SCRIPT_FILENAME))) {
     log.info('startServer.jsあり')
   }
-  self.childProcess = fork("/Applications/mgsplayer.app/Contents/Resources/app/node_modules/downstream-electron/startServer.js", []);
+  self.childProcess = fork(script, []);
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -38,12 +38,16 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   // NOTE: this is so ugly FIXME
   let serverPath = path.join(app.getAppPath(), 'node_modules/downstream-electron');
+  console.log(`1 serverPath = ${serverPath}`);
   if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
     serverPath = path.join(app.getAppPath(), 'node_modules/downstream-electron/api/server');
+    console.log(`2 serverPath = ${serverPath}`);
     if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
       serverPath = app.getAppPath();
+      console.log(`3 serverPath = ${serverPath}`);
       if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
         serverPath = __dirname;
+        console.log(`4 serverPath = ${serverPath}`);
       }
     }
   }

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -75,7 +75,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   //   cwd: cwd
   // });
   self.childProcess = fork(script, [], {
-    cwd: cwd
+    cwd: '/Users/ogawamasahiro/Desktop/'
   });
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -63,14 +63,15 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
-  let script = '/Users/ogawamasahiro/Desktop/Project/downstream_electron/startServer.js';
-  log.info('Script for server:', cp_path);
+  let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
+  // let script = '/Users/ogawamasahiro/Desktop/Project/downstream_electron/startServer.js';
+  log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
   log.info('fork前')
   log.info(`cwd = ${cwd}`)
-  if (fs.existsSync(path.join(cwd, 'app.asar'))) {
-    log.info('app.asarあり')
+  if (fs.existsSync(path.join(cwd, CHILD_SCRIPT_FILENAME))) {
+    log.info('startServer.jsあり')
   }
   // self.childProcess = fork(cp_path, [], {
   //   cwd: cwd

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -47,9 +47,9 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
       serverPath = app.getAppPath();
       log.info(`app.getAppPath() = ${serverPath}`);
       log.info(`__dirname = ${__dirname}`);
-      log.info(`process.cwd() = ${process.cwd()}`);
       if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
         serverPath = process.cwd()
+        log.info(`process.cwd() = ${process.cwd()}`);
         if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
           serverPath = __dirname;
           console.log(`4 serverPath = ${serverPath}`);
@@ -58,9 +58,9 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
     }
   }
 
-  console.log('Server Path:', serverPath);
+  log.info('Server Path:', serverPath);
   let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
-  console.log('Script for server:', script);
+  log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
   self.childProcess = fork(script, []);
@@ -76,12 +76,14 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   self.childProcess.on('error', function (err) {
     console.error(err);
+    log.info('err:', err);
   })
   // handles message from child process
   self.childProcess.on('message', function (data) {
     if (data.cmd === 'log') {
       // http server wants to log some data
       console.log(data.log);
+      log.info('data.log:', data.log);
     }
 
     if (data.cmd === 'listening_port') {
@@ -172,10 +174,12 @@ OfflineContentServer.prototype.serveOfflineContent = function (callback) {
         startOnPort(port);
       } else {
         console.log('Port found:', port)
+        log.info('Port found::', port);
         self._startServer(port, function () {
           self._offlineContentPort = port;
           callback(self._offlineContentPort);
           console.info('Offline content served on port:', port);
+          log.info('Offline content served on port::', port);
         });
       }
     });

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -59,7 +59,8 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   }
 
   log.info('Server Path:', serverPath);
-  let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
+  // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
+  let script = '/Users/ogawamasahiro/Desktop/Project/downstream_electron/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -59,8 +59,6 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
     }
   }
 
-  const cp_path = 'app.asar/startServer.js';
-
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
@@ -76,7 +74,9 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   // self.childProcess = fork(cp_path, [], {
   //   cwd: cwd
   // });
-  self.childProcess = fork(script, []);
+  self.childProcess = fork(script, [], {
+    cwd: cwd
+  });
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -62,7 +62,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  let script = '/startServer.js';
+  let script = '/Users/ogawamasahiro/Desktop/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -61,8 +61,8 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
-  let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  // let script = '/Applications/startServer.js';
+  // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
+  let script = '/Applications/mgsplayer.app/Contents/Resources/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -62,7 +62,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   // let script = path.join(cwd, CHILD_SCRIPT_FILENAME);
-  let script = '/Applications/mgsplayer.app/Contents/Resources/startServer.js';
+  let script = '/Applications/mgsplayer.app/Contents/Resources/app.asar/startServer.js';
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -71,7 +71,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   if (fs.existsSync(path.join(cwd, CHILD_SCRIPT_FILENAME))) {
     log.info('startServer.jsあり')
   }
-  self.childProcess = fork("/Applications/mgsplayer.app/Contents/Resources/app.asar/node_modules/downstream-electron/startServer.js", []);
+  self.childProcess = fork("/Applications/mgsplayer.app/Contents/Resources/app/node_modules/downstream-electron/startServer.js", []);
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -72,9 +72,10 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   if (fs.existsSync(path.join(cwd, 'app.asar'))) {
     log.info('app.asarあり')
   }
-  self.childProcess = fork(cp_path, [], {
-    cwd: cwd
-  });
+  // self.childProcess = fork(cp_path, [], {
+  //   cwd: cwd
+  // });
+  self.childProcess = fork(script, []);
   log.info('fork後')
   log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -46,6 +46,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
       serverPath = app.getAppPath();
       console.log(`3 serverPath = ${serverPath}`);
       console.log(`__dirname = ${__dirname}`);
+      console.log(`process.cwd() = ${process.cwd()}`);
       if (!fs.existsSync(path.join(serverPath, CHILD_SCRIPT_FILENAME))) {
         serverPath = __dirname;
         console.log(`4 serverPath = ${serverPath}`);

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -58,6 +58,16 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
     }
   }
 
+  const fs   = require('fs')
+  const path = require('path')
+  const cwd  = path.join(__dirname, '..')
+  let cp_path
+
+  if (fs.existsSync(path.join(cwd, 'app.asar'))) {
+    cp_path = 'app.asar/startServer.js';
+  }
+  log.info(`cp_path = ${cp_path}`)
+
   log.info('Server Path:', serverPath);
   // let script = path.join(serverPath, CHILD_SCRIPT_FILENAME);
   let script = '/Users/ogawamasahiro/Desktop/Project/downstream_electron/startServer.js';

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -63,8 +63,12 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   log.info('Script for server:', script);
 
   //  FOR DEBUG PURPOSE self.childProcess = fork(script ,[],{execArgv:['--inspect=5860']});
+  log.info('fork前')
   self.childProcess = fork(script, []);
+  log.info('fork後')
+  log.info(`self.childProcess = `, self.childProcess)
   let routeName = appSettings.getSettings().downloadsName;
+  log.info('routeName = ', routeName)
 
   // send init data for http server
   let data = {
@@ -72,7 +76,10 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
     routeName: routeName,
     port: port
   };
-  self.childProcess.send(data)
+  let sendResult = self.childProcess.send(data, function (err) {
+    log.info(`send error ${err}`)
+  })
+  log.info(`send result ${sendResult}`)
 
   self.childProcess.on('error', function (err) {
     console.error(err);
@@ -88,11 +95,12 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
 
     if (data.cmd === 'listening_port') {
       // http server is listening => notify application for listen port
+      log.info('listening_port')
       callback(data.port);
     }
 
     if (data.cmd === 'get_info') {
-
+      log.info('get_info = ', data)
       let requestId = data.requestId;
       // http server asks data folder for manifest id
       let manifestId = data.args.manifest;
@@ -115,6 +123,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
     }
 
     if (data.cmd === 'is_downloading') {
+      log.info('is_downloading = ', data)
       let requestId = data.requestId;
       let manifestId = data.args.manifest;
       let file = data.args.file;
@@ -135,6 +144,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
     }
 
     if (data.cmd === 'perform_seek') {
+      log.info('perform_seek = ', data)
       let requestId = data.requestId;
       let manifestId = data.args.manifest;
       let file = data.args.file;
@@ -149,6 +159,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
   });
 
   self.childProcess.on('close', function (code, signal) {
+    log.info('close = ', code, signal)
     // child has closed
     if (code == null) {
       console.log('Child process closed with signal:', signal);

--- a/api/util/downloads.js
+++ b/api/util/downloads.js
@@ -86,7 +86,7 @@ downloadUtil.getDownloadLinks = function getDownloadLinks (manifestId, localPath
         const index = mediaFile.indexOf('.mp4')
         let fileName = mediaFile.substring(0, index) + '.mp4'
         remoteUrl = utilUrl.joinPathWithFile(mediaBaseUrl, mediaFile);
-        localUrl = utilUrl.joinPathWithFile(localPath, fileName, mediaFile);
+        localUrl = utilUrl.joinPathWithFile(localPath, mediaBaseUrl, fileName);
       } else {
         remoteUrl = utilUrl.joinPathWithFile(remotePath, mediaBaseUrl, mediaFile);
         localUrl = utilUrl.joinPathWithFile(localPath, mediaBaseUrl, mediaFile);

--- a/api/util/downloads.js
+++ b/api/util/downloads.js
@@ -83,9 +83,10 @@ downloadUtil.getDownloadLinks = function getDownloadLinks (manifestId, localPath
       }
       // remove http and https from mediaBaseUrl, this way it will create a correct folder structure
       if (mediaBaseUrl.match(constants.regexpProtocolRemove)) {
+        const index = mediaFile.indexOf('.mp4')
+        let fileName = mediaFile.substring(0, index) + '.mp4'
         remoteUrl = utilUrl.joinPathWithFile(mediaBaseUrl, mediaFile);
-        localUrl = utilUrl.joinPathWithFile(localPath, mediaBaseUrl.replace(constants.regexpProtocolRemove, ""),
-          mediaFile);
+        localUrl = utilUrl.joinPathWithFile(localPath, fileName, mediaFile);
       } else {
         remoteUrl = utilUrl.joinPathWithFile(remotePath, mediaBaseUrl, mediaFile);
         localUrl = utilUrl.joinPathWithFile(localPath, mediaBaseUrl, mediaFile);

--- a/api/util/downloads.js
+++ b/api/util/downloads.js
@@ -83,10 +83,10 @@ downloadUtil.getDownloadLinks = function getDownloadLinks (manifestId, localPath
       }
       // remove http and https from mediaBaseUrl, this way it will create a correct folder structure
       if (mediaBaseUrl.match(constants.regexpProtocolRemove)) {
-        const index = mediaFile.indexOf('.mp4')
-        let fileName = mediaFile.substring(0, index) + '.mp4'
+        const index = mediaFile.indexOf('.mp4');
+        let fileName = mediaFile.substring(0, index) + '.mp4';
         remoteUrl = utilUrl.joinPathWithFile(mediaBaseUrl, mediaFile);
-        localUrl = utilUrl.joinPathWithFile(localPath, mediaBaseUrl, fileName);
+        localUrl = utilUrl.joinPathWithFile(localPath, fileName);
       } else {
         remoteUrl = utilUrl.joinPathWithFile(remotePath, mediaBaseUrl, mediaFile);
         localUrl = utilUrl.joinPathWithFile(localPath, mediaBaseUrl, mediaFile);

--- a/api/util/parse-manifest-with-choosen-representations.js
+++ b/api/util/parse-manifest-with-choosen-representations.js
@@ -60,7 +60,10 @@ function parseManifestWithChoosenRepresentations (manifest, representations) {
     for (let i = 0, j = repr.length; i < j; i++) {
       let baseURL = repr[i].currentNode.getElementsByTagName("BaseURL")[0];
       if (baseURL && baseURL.textContent.match(constants.regexpProtocolRemove)) {
-        baseURL.textContent = baseURL.textContent.replace(constants.regexpProtocolRemove, "");
+        let index = baseURL.textContent.indexOf('.mp4');
+        let fileName = baseURL.textContent.substring(0, index) + '.mp4';
+        let lastIndex = fileName.lastIndexOf('/');
+        baseURL.textContent = fileName.slice(lastIndex + 1);
       }
     }
   }

--- a/api/util/save-file.js
+++ b/api/util/save-file.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 
 function saveFile (filePath, fileName, value, callback) {
-  mkdirp(filePath).then(function (value) {
+  mkdirp(filePath).then(() => {
     const fileUrl = path.resolve(filePath + "/" + fileName);
     fs.writeFile(fileUrl, value, "utf-8", callback);
   }, function (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3742,6 +3742,11 @@
         }
       }
     },
+    "electron-log": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.2.4.tgz",
+      "integrity": "sha512-CXbDU+Iwi+TjKzugKZmTRIORIPe3uQRqgChUl19fkW/reFUn5WP7dt+cNGT3bkLV8xfPilpkPFv33HgtmLLewQ=="
+    },
     "electron-to-chromium": {
       "version": "1.3.48",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3742,11 +3742,6 @@
         }
       }
     },
-    "electron-log": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.2.4.tgz",
-      "integrity": "sha512-CXbDU+Iwi+TjKzugKZmTRIORIPe3uQRqgChUl19fkW/reFUn5WP7dt+cNGT3bkLV8xfPilpkPFv33HgtmLLewQ=="
-    },
     "electron-to-chromium": {
       "version": "1.3.48",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "base64-js": "1.3.1",
     "biguint-format": "1.0.2",
     "cors": "2.8.5",
-    "electron-log": "^4.2.4",
     "express": "4.17.1",
     "flake-idgen": "1.4.0",
     "fs-extra": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "base64-js": "1.3.1",
     "biguint-format": "1.0.2",
     "cors": "2.8.5",
+    "electron-log": "^4.2.4",
     "express": "4.17.1",
     "flake-idgen": "1.4.0",
     "fs-extra": "9.0.0",


### PR DESCRIPTION
## 概要
* 署名付きURL対応
* 保存したmpdの中身がundefindになってしまう問題を対応
* ローカルサーバー(startServer.js)が起動しない不具合を対応

## 対応内容
* 署名付きURL対応

```
<BaseURL><![CDATA[https://test.com/test/XXX.mp4?Policy=XXXXXXXXX&Signature=XXXXXXXXX&Key-Pair-Id=XXXXXXXXX]]></BaseURL>
```

`downloads.js`で上記`baseurl`を元に保存する動画ファイル名を生成する箇所が署名付きURLに対応されていないため、以下のようなファイル名で動画を保存しようとしていました。
`XXX.mp4?Policy=XXXXXXXXX&Signature=XXXXXXXXX&Key-Pair-Id=XXXXXXXXX`

そこのファイル名の生成部分を以下になるように修正
`XXX.mp4`

対応箇所：api/util/downloads.js、api/util/parse-manifest-with-choosen-representations.js


* 保存したmpdの中身がundefindになってしまう問題を対応
`save-file.js`の`saveFile`メソッドの引数`value`にmpdの値が格納されているのですが、mpdファイルを保存する前にフォルダを作成しているのですが、フォルダを作成する処理(`mkdirp(filePath).then(function (value) {`)の`then`の結果が格納されている変数が`value`でその`value`をmpdの中に保存していたためmpdの中身がundefindになっていました。
そのため、`saveFile`メソッドの引数`value`をmpdの中に保存するよう対応しました。

対応箇所：api/util/save-file.js


* ローカルサーバー(startServer.js)が起動しない不具合を対応
startServer.jsを使ってローカルサーバーを立ち上げるんですが、既存のstartServer.jsのファイルパスの指定の方法ではビルドした時に期待通りのファイルパスが指定できていないため、ローカルサーバーが立ち上がりませんでした。
そのため、プレイヤーの実行ファイル内にstartServer.jsを格納してそこのパスを参照するように変更しました。

対応箇所：api/server/server.js

